### PR TITLE
[enhancement] Added support for MFA to login method of API.py

### DIFF
--- a/pwndocapi/API.py
+++ b/pwndocapi/API.py
@@ -40,10 +40,10 @@ class API(object):
         self.verbose = verbose
         self.user = {"token": "", "refreshToken": ""}
 
-    def login(self, username, password):
+    def login(self, username, password, totp=""):
         r = self.session.post(
             self.target + "/api/users/token",
-            json={"username": username, "password": password, "totpToken": ""},
+            json={"username": username, "password": password, "totpToken": totp},
             verify=False
         )
         if r.json()["status"] == "success":
@@ -57,7 +57,7 @@ class API(object):
             self.loggedin = True
         elif r.json()["status"] == "error":
             if self.verbose:
-                print("[!] Login error. (%s)" % r.json()["status"])
+                print("[!] Login error. (%s)" % r.json()["datas"])
             self.loggedin = False
         return self.loggedin
 


### PR DESCRIPTION
Added support to pass TOTP token to API.login method. The default is still to not use a null token unless a token is passed. Also, fixed the output error message for the login to show the error "datas" instead of the "status" which seemed to be a mistake.